### PR TITLE
Feature/improve elasticsearch indices

### DIFF
--- a/configs/es_schemas/es_genres_schema.json
+++ b/configs/es_schemas/es_genres_schema.json
@@ -46,7 +46,12 @@
         "type": "keyword"
       },
       "name": {
-        "type": "text"
+        "type": "text",
+        "fields": {
+          "raw": { 
+            "type":  "keyword"
+          }
+        }
       },
       "description": {
         "type": "text",

--- a/configs/es_schemas/es_persons_schema.json
+++ b/configs/es_schemas/es_persons_schema.json
@@ -46,7 +46,12 @@
           "type": "keyword"
         },
         "full_name": {
-          "type": "text"
+          "type": "text",
+          "fields": {
+            "raw": { 
+              "type":  "keyword"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Closing #6 

Completed:

- [x] Improve Elasticsearch 'persons' index to enable both sorting and filtering.
- [x] Improve Elasticsearch 'genres' index to enable both sorting and filtering.

String fields (`name` at `genres` index and `full_name` at `persons` index) have been be mapped as a text fields for full-text search (filtering), and as a keyword fields for sorting or aggregations.

See docs related to [Elasticsearch multi-field functionality](https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html).